### PR TITLE
Sync with upstream 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,6 +26,7 @@ Secret salt to enhance and refine Thaumcraft 4
 # Credits
 * rndmorris - Project co-lead
 * Midnight145 - Project co-lead
+* nicksitnikov - Developer
 * jss2a98aj - Metadata safety checks from [BugTorch](https://github.com/jss2a98aj/BugTorch)
 * The GTNH Team - The Mixin framework, several mixins from [Hodgepodge](https://github.com/GTNewHorizons/Hodgepodge)
 * Christopher "BlayTheNinth" Baker - Thaumic Inventory Scanning

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
@@ -62,6 +62,9 @@ public abstract class MixinContainerArcaneWorkbench_SingleWandReplacement extend
                 }
             }
 
+            // Staves & Staffters cannot be used to supply vis for crafting
+            if (itemWand.isStaff(originalWand)) return;
+
             // Vis is spent using the original wand, which is why that loop above is necessary.
             if (itemWand.consumeAllVisCrafting(originalWand, this.ip.player, visPrice, true)) {
                 if (SalisConfig.features.preserveWandVis.isEnabled()) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
@@ -38,6 +38,10 @@ public class MixinGuiArcaneWorkbench_SingleWandReplacement {
                 final ItemStack slot = this.tileEntity.getStackInSlot(i);
                 if (slot != null && slot.getItem() instanceof ItemWandCasting itemWand) {
                     // Found a wand in table
+
+                    // Staves & Staffters cannot be used to supply vis for crafting
+                    if (itemWand.isStaff(slot)) return null;
+
                     if ((CustomRecipes.replaceWandCapsRecipe != null && CustomRecipes.replaceWandCapsRecipe
                         .matches(this.tileEntity, this.ip.player.worldObj, KnowItAll.getInstance()))
                         || (CustomRecipes.replaceWandCoreRecipe != null && CustomRecipes.replaceWandCoreRecipe


### PR DESCRIPTION
Prevents Single Wand Replacement from using staff vis & adds a name to the credits.